### PR TITLE
Update dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,10 +17,10 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-random": "^0.2.0",
+    "purescript-random": "^0.2.1",
     "purescript-exceptions": "^0.3.0",
     "purescript-transformers": "^0.6.1",
-    "purescript-free": "^0.5.0",
+    "purescript-free": "^0.6.0",
     "purescript-machines": "^0.7.0",
     "purescript-arrays": "^0.4.0",
     "purescript-strings": "^0.5.2",


### PR DESCRIPTION
This is a breaking change due to bumping `free`, so should be released as `v0.11.0`.