### PR TITLE
Add DivisionRing instance for ApproxNumber 

### DIFF
--- a/src/Test/StrongCheck/Data/ApproxNumber.purs
+++ b/src/Test/StrongCheck/Data/ApproxNumber.purs
@@ -39,6 +39,9 @@ instance ringApproxNumber :: Ring ApproxNumber where
 
 instance commutativeRingApproxNumber :: CommutativeRing ApproxNumber
 
+instance divisionRingApproxNumber :: DivisionRing ApproxNumber where
+  recip (ApproxNumber x) = ApproxNumber (1.0 / x)
+
 instance euclideanRingApproxNumber :: EuclideanRing ApproxNumber where
   degree (ApproxNumber x) = degree x
   div (ApproxNumber x) (ApproxNumber y) = ApproxNumber (x / y)


### PR DESCRIPTION
This pull request is necessary for `strongcheck-laws` to be able to verify a `DivisionRing` instance for `ApproxNumber`. See https://github.com/garyb/purescript-strongcheck-laws/pull/4 for details there.

These two pull requests are in tandem. The other one will fail CI until this update is available to that repository. However, I've included it here for the time being despite.